### PR TITLE
Allow for text points for ERAM map support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,6 +358,7 @@ dependencies = [
  "geojson",
  "quick-xml",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -460,12 +461,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,14 +492,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -678,3 +674,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ geojson = "0.24.2"
 quick-xml = { version = "0.38.3", features = ["serialize"] }
 # Deserialize XML
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.149"

--- a/src/label.rs
+++ b/src/label.rs
@@ -8,6 +8,7 @@ use geo::{coord, Centroid, Coord};
 
 pub struct Label {
     pub lines: Vec<Vec<Coord>>,
+    pub text: String,
 }
 
 pub fn create(polys: &[Poly], mag_var: f64) -> Result<Vec<Label>> {
@@ -76,7 +77,7 @@ pub fn create(polys: &[Poly], mag_var: f64) -> Result<Vec<Label>> {
             }
         }
 
-        let label = Label { lines: digits };
+        let label = Label { lines: digits, text: mva.clone() };
         labels.push(label);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,13 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 
-pub fn convert(source: PathBuf, name: String, mag_var: f64) -> Result<()> {
+pub fn convert(source: PathBuf, name: String, mag_var: f64, text_labels: bool) -> Result<()> {
     println!("[jetsa] Parsing source XML file...");
     let aixm = fs::read_to_string(source)?;
 
     println!("[jetsa] Writing GeoJSON file...");
     let map = Map::build(aixm, name, mag_var)?;
-    writer::write(map)?;
+    writer::write(map, text_labels)?;
 
     println!("[jetsa] Complete!");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,12 +19,16 @@ pub struct Cli {
     #[arg(short, long)]
     /// Path of the FAA XML file
     pub source: PathBuf,
+
+    #[arg(short, long)]
+    /// Output labels as text points instead of drawn lines
+    pub text_labels: bool,
 }
 
 fn main() -> Result<()> {
     let args = Cli::parse();
 
-    convert(args.source, args.name, args.magnetic_variation)?;
+    convert(args.source, args.name, args.magnetic_variation, args.text_labels)?;
 
     Ok(())
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -13,7 +13,7 @@ impl Map {
     pub fn build(aixm: String, name: String, mag_var: f64) -> Result<Self> {
         let polys = poly::from_aixm_str(&aixm)?;
         let labels = label::create(&polys, mag_var)?;
-
+        
         let map = Map { name, polys, digits: labels };
 
         Ok(map)


### PR DESCRIPTION
This PR adds a command line option to include the MVA altitudes as point objects instead of drawing the digits onto the map as line segments. This is helpful for the TAV XMLs for use in CRC ERAM, as ERAM supports displaying points on geomaps.